### PR TITLE
Improve java.lang.Math

### DIFF
--- a/javacompiler/java/lang/Math.java
+++ b/javacompiler/java/lang/Math.java
@@ -29,10 +29,7 @@ public class Math implements __stub__ {
         return (a>b) ? a : b;
     }
 
-    /// @brief
     /// Returns the greater of two `float` values.
-    ///
-    /// @note This function is non-standard
     public static float max( float a, float b ){
         return (a>b) ? a : b;
     }
@@ -63,10 +60,7 @@ public class Math implements __stub__ {
         return (a<b) ? a : b;
     }
 
-    /// @brief
     /// Returns the lesser of two `float` values.
-    ///
-    /// @note This function is non-standard
     public static float min( float a, float b ){
         return (a<b) ? a : b;
     }

--- a/javacompiler/java/lang/Math.java
+++ b/javacompiler/java/lang/Math.java
@@ -34,6 +34,11 @@ public class Math implements __stub__ {
         return (a>b) ? a : b;
     }
 
+    /// Returns the greater of two `long` values.
+    public static long max( long a, long b ){
+        return (a>b) ? a : b;
+    }
+
     /// @brief
     /// Returns the greater of two `uint` values.
     ///
@@ -62,6 +67,11 @@ public class Math implements __stub__ {
 
     /// Returns the lesser of two `float` values.
     public static float min( float a, float b ){
+        return (a<b) ? a : b;
+    }
+
+    /// Returns the lesser of two `long` values.
+    public static long min( long a, long b ){
         return (a<b) ? a : b;
     }
 

--- a/javacompiler/java/lang/Math.java
+++ b/javacompiler/java/lang/Math.java
@@ -196,4 +196,16 @@ public class Math implements __stub__ {
         q >>= 12;
         return __inline_cpp__("up_java::up_lang::uc_float::fromInternal(q)");
     }
+
+    /// @brief
+    /// Returns the signum function of the argument; zero if the argument is zero,
+    /// 1.0f if the argument is greater than zero, -1.0f if the argument is less than zero. 
+    public static float signum( float f ){
+        // Get the internal fixed point representation as a signed integer.
+        int internal = (int)__inline_cpp__("f.getInternal()");
+
+        // The rest of the logic works as normal,
+        // no pesky `NaN`s or `-0.0f`s to worry about.
+        return (internal == 0) ? 0.0f : (internal < 0) ? -1.0f : 1.0f;
+    }
 }

--- a/javacompiler/java/lang/Math.java
+++ b/javacompiler/java/lang/Math.java
@@ -7,6 +7,9 @@ public class Math implements __stub__ {
     /// The `float` value that is closer than any other to pi, the ratio of the circumference of a circle to its diameter.
     public static final float PI = 3.1415926535897932384626433832795028841971f;
 
+    /// The `float` value that is closer than any other to e, the base of the natural logarithms.
+    public static final float E = 2.7182818284590452353602874713526624977572f;
+
     /// @brief
     /// Converts an angle measured in degrees to an approximately equivalent angle measured in radians.
     ///

--- a/javacompiler/java/lang/Math.java
+++ b/javacompiler/java/lang/Math.java
@@ -19,6 +19,18 @@ public class Math implements __stub__ {
         return (deg*PI) / 180.0f;
     }
 
+    /// @brief
+    /// Converts an angle measured in radians to an approximately equivalent angle measured in degrees.
+    ///
+    /// @param
+    /// radians An angle expressed in radians.
+    ///
+    /// @return
+    /// An angle expressed in degrees.
+    public static float toDegrees( float radians ){
+        return ((radians * 180.0f) / PI);
+    }
+
     /// Returns the greater of two `double` values.
     public static double max( double a, double b ){
         return (a>b) ? a : b;


### PR DESCRIPTION
Adds `E`, `signum`, `toDegrees`, `min(long, long)` and `max(long, long)` to `java.lang.Math`.
Also corrects a previous documentation error caused by copy-pasting.

(This was also supposed to include some 'non-standard' notices, but I kept messing them up so I'm putting them off until another day.)