### PR TITLE
Cast char to int to fix Integer.parseInt

### DIFF
--- a/javacompiler/java/lang/Integer.java
+++ b/javacompiler/java/lang/Integer.java
@@ -18,7 +18,7 @@ public class Integer {
         int acc=0;
         for( int i=0; s[i] >= '0' && s[i] <= '9'; ++i ){
             acc *= 10;
-            acc += s[i] - '0';
+            acc += (int)(s[i] - '0');
         }
         return acc;
     }


### PR DESCRIPTION
The compiler couldn't do `+=` with int += char, so we have to cast the char to int.